### PR TITLE
Added custom_values to PartialDependenceDisplay plotting

### DIFF
--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -38,36 +38,29 @@ __all__ = [
 
 def _grid_from_X(X, percentiles, grid_resolution, custom_values):
     """Generate a grid of points based on the percentiles of X.
-
     The grid is a cartesian product between the columns of ``values``. The
     ith column of ``values`` consists in ``grid_resolution`` equally-spaced
     points between the percentiles of the jth column of X.
     If ``grid_resolution`` is bigger than the number of unique values in the
     jth column of X, then those unique values will be used instead.
-
     Parameters
     ----------
     X : ndarray, shape (n_samples, n_target_features)
         The data.
-
     percentiles : tuple of floats
         The percentiles which are used to construct the extreme values of
         the grid. Must be in [0, 1].
-
     grid_resolution : int
         The number of equally spaced points to be placed on the grid for each
         feature.
-
     custom_values: dict
         Mapping from column index of X to an array-like of values where
         the partial dependence should be calculated for that feature
-
     Returns
     -------
     grid : ndarray, shape (n_points, n_target_features)
         A value for each feature at each point in the grid. ``n_points`` is
         always ``<= grid_resolution ** X.shape[1]``.
-
     values : list of 1d ndarrays
         The values with which the grid has been created. The size of each
         array ``values[j]`` is either ``grid_resolution``, the number of
@@ -253,15 +246,11 @@ def partial_dependence(
     custom_values=None,
 ):
     """Partial dependence of ``features``.
-
     Partial dependence of a feature (or a set of features) corresponds to
     the average response of an estimator for each possible value of the
     feature.
-
     Read more in the :ref:`User Guide <partial_dependence>`.
-
     .. warning::
-
         For :class:`~sklearn.ensemble.GradientBoostingClassifier` and
         :class:`~sklearn.ensemble.GradientBoostingRegressor`, the
         `'recursion'` method (used by default) will not account for the `init`
@@ -276,24 +265,20 @@ def partial_dependence(
         :class:`~sklearn.ensemble.GradientBoostingRegressor`, not to
         :class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
         :class:`~sklearn.ensemble.HistGradientBoostingRegressor`.
-
     Parameters
     ----------
     estimator : BaseEstimator
         A fitted estimator object implementing :term:`predict`,
         :term:`predict_proba`, or :term:`decision_function`.
         Multioutput-multiclass classifiers are not supported.
-
     X : {array-like or dataframe} of shape (n_samples, n_features)
         ``X`` is used to generate a grid of values for the target
         ``features`` (where the partial dependence will be evaluated), and
         also to generate values for the complement features when the
         `method` is 'brute'.
-
     features : array-like of {int, str}
         The feature (e.g. `[0]`) or pair of interacting features
         (e.g. `[(0, 1)]`) for which the partial dependency should be computed.
-
     response_method : {'auto', 'predict_proba', 'decision_function'}, \
             default='auto'
         Specifies whether to use :term:`predict_proba` or
@@ -303,18 +288,14 @@ def partial_dependence(
         and we revert to :term:`decision_function` if it doesn't exist. If
         ``method`` is 'recursion', the response is always the output of
         :term:`decision_function`.
-
     percentiles : tuple of float, default=(0.05, 0.95)
         The lower and upper percentile used to create the extreme values
         for the grid. Must be in [0, 1].
-
     grid_resolution : int, default=100
         The number of equally spaced points on the grid, for each target
         feature.
-
     method : {'auto', 'recursion', 'brute'}, default='auto'
         The method used to calculate the averaged predictions:
-
         - `'recursion'` is only supported for some tree-based estimators
           (namely
           :class:`~sklearn.ensemble.GradientBoostingClassifier`,
@@ -331,88 +312,70 @@ def partial_dependence(
           the average of the Individual Conditional Expectation (ICE) by
           design, it is not compatible with ICE and thus `kind` must be
           `'average'`.
-
         - `'brute'` is supported for any estimator, but is more
           computationally intensive.
-
         - `'auto'`: the `'recursion'` is used for estimators that support it,
           and `'brute'` is used otherwise.
-
         Please see :ref:`this note <pdp_method_differences>` for
         differences between the `'brute'` and `'recursion'` method.
-
     kind : {'legacy', 'average', 'individual', 'both'}, default='legacy'
         Whether to return the partial dependence averaged across all the
         samples in the dataset or one line per sample or both.
         See Returns below.
-
         Note that the fast `method='recursion'` option is only available for
         `kind='average'`. Plotting individual dependencies requires using the
         slower `method='brute'` option.
-
         .. versionadded:: 0.24
         .. deprecated:: 0.24
             `kind='legacy'` is deprecated and will be removed in version 1.1.
             `kind='average'` will be the new default. It is intended to migrate
             from the ndarray output to :class:`~sklearn.utils.Bunch` output.
-
     custom_values: dict
-        A dictionary mapping an element of `features` to an array of values where
+        A dictionary mapping the index of an element of `features` to an array of values where
         the partial dependence should be calculated for that feature. Setting a range
         of values for a feature overrides `grid_resolution` and `percentiles`.
-
-
     Returns
     -------
     predictions : ndarray or :class:`~sklearn.utils.Bunch`
-
         - if `kind='legacy'`, return value is ndarray of shape (n_outputs, \
                 len(values[0]), len(values[1]), ...)
             The predictions for all the points in the grid, averaged
             over all samples in X (or over the training data if ``method``
             is 'recursion').
-
         - if `kind='individual'`, `'average'` or `'both'`, return value is \
                 :class:`~sklearn.utils.Bunch`
             Dictionary-like object, with the following attributes.
-
             individual : ndarray of shape (n_outputs, n_instances, \
                     len(values[0]), len(values[1]), ...)
                 The predictions for all the points in the grid for all
                 samples in X. This is also known as Individual
                 Conditional Expectation (ICE)
-
             average : ndarray of shape (n_outputs, len(values[0]), \
                     len(values[1]), ...)
                 The predictions for all the points in the grid, averaged
                 over all samples in X (or over the training data if
                 ``method`` is 'recursion').
                 Only available when kind='both'.
-
             values : seq of 1d ndarrays
                 The values with which the grid has been created. The generated
                 grid is a cartesian product of the arrays in ``values``.
                 ``len(values) == len(features)``. The size of each array
                 ``values[j]`` is either ``grid_resolution``, or the number of
                 unique values in ``X[:, j]``, whichever is smaller.
-
         ``n_outputs`` corresponds to the number of classes in a multi-class
         setting, or to the number of tasks for multi-output regression.
         For classical regression and binary classification ``n_outputs==1``.
         ``n_values_feature_j`` corresponds to the size ``values[j]``.
-
     values : seq of 1d ndarrays
         The values with which the grid has been created. The generated grid
         is a cartesian product of the arrays in ``values``. ``len(values) ==
         len(features)``. The size of each array ``values[j]`` is either
         ``grid_resolution``, or the number of unique values in ``X[:, j]``,
         whichever is smaller. Only available when `kind="legacy"`.
-
     See Also
     --------
     PartialDependenceDisplay.from_estimator : Plot Partial Dependence.
     PartialDependenceDisplay : Partial Dependence visualization.
-
     Examples
     --------
     >>> X = [[0, 0, 2], [1, 0, 0]]

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -44,6 +44,7 @@ def plot_partial_dependence(
     kind="average",
     subsample=1000,
     random_state=None,
+    custom_values=None,
 ):
     """Partial dependence (PD) and individual conditional expectation (ICE)
     plots.
@@ -263,6 +264,11 @@ def plot_partial_dependence(
 
         .. versionadded:: 0.24
 
+    custom_values: dict
+        A dictionary mapping the index of an element of `features` to an array of values where
+        the partial dependence should be calculated for that feature. Setting a range
+        of values for a feature overrides `grid_resolution` and `percentiles`.
+
     Returns
     -------
     display : :class:`~sklearn.inspection.PartialDependenceDisplay`
@@ -307,6 +313,7 @@ def plot_partial_dependence(
         kind=kind,
         subsample=subsample,
         random_state=random_state,
+        custom_values=custom_values,
     )
 
 
@@ -333,6 +340,7 @@ def _plot_partial_dependence(
     kind="average",
     subsample=1000,
     random_state=None,
+    custom_values=None,
 ):
     """See PartialDependenceDisplay.from_estimator for details"""
     import matplotlib.pyplot as plt  # noqa
@@ -443,6 +451,7 @@ def _plot_partial_dependence(
             grid_resolution=grid_resolution,
             percentiles=percentiles,
             kind=kind,
+            custom_values=custom_values,
         )
         for fxs in features
     )
@@ -686,6 +695,7 @@ class PartialDependenceDisplay:
         kind="average",
         subsample=1000,
         random_state=None,
+        custom_values=None,
     ):
         """Partial dependence (PD) and individual conditional expectation (ICE) plots.
 
@@ -889,6 +899,11 @@ class PartialDependenceDisplay:
             `None` and `kind` is either `'both'` or `'individual'`.
             See :term:`Glossary <random_state>` for details.
 
+        custom_values : dict
+            A dictionary mapping the index of an element of `features` to an array of values where
+            the partial dependence should be calculated for that feature. Setting a range
+            of values for a feature overrides `grid_resolution` and `percentiles`.
+
         Returns
         -------
         display : :class:`~sklearn.inspection.PartialDependenceDisplay`
@@ -931,6 +946,7 @@ class PartialDependenceDisplay:
             kind=kind,
             subsample=subsample,
             random_state=random_state,
+            custom_values=custom_values,
         )
 
     def _get_sample_count(self, n_samples):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This allows passage of a custom_values dictionary to the .from_estimator() method of the PartialDependenceDisplay object

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
